### PR TITLE
feat: Add CI/CD pipeline and NuGet package publishing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,113 @@
+# CI/CD Pipeline for TBC IntegrationService Client
+# Uses centralized workflows from AppifySheets/github-workflows repository
+name: CI/CD Pipeline
+
+on:
+  # Trigger on pushes to main branch
+  push:
+    branches: [ main ]
+    # Trigger on version tags (e.g., v1.0.0)
+    tags: [ 'v*' ]
+  
+  # Trigger on pull requests to main
+  pull_request:
+    branches: [ main ]
+  
+  # Allow manual workflow dispatch
+  workflow_dispatch:
+    inputs:
+      publish-packages:
+        description: 'Publish NuGet packages'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  # Build and test job - runs on all triggers
+  build-test:
+    name: Build and Test
+    uses: AppifySheets/github-workflows/.github/workflows/dotnet-build-test.yml@master
+    with:
+      # Find and build the solution file
+      solution-path: '*.sln'
+      # Use .NET 8.0
+      dotnet-version: '8.0.x'
+      # Find and run all test projects
+      test-projects: '**/*Tests.csproj'
+      # Build in Release configuration
+      build-configuration: 'Release'
+      # Run tests
+      run-tests: true
+      # Upload test results for visibility in PR
+      upload-test-results: true
+      # Upload code coverage reports
+      upload-coverage: false
+
+  # Publish NuGet packages - only on version tags or manual dispatch
+  publish-nuget:
+    name: Publish NuGet Packages
+    # Only run on version tags or manual dispatch with publish flag
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-packages == 'true')
+    needs: build-test
+    uses: AppifySheets/github-workflows/.github/workflows/dotnet-nuget-publish.yml@master
+    with:
+      # Package both the client library and the immutable types library
+      project-paths: |
+        AppifySheets.TBC.IntegrationService.Client/AppifySheets.TBC.IntegrationService.Client.csproj;
+        AppifySheets.Immutable.BankIntegrationTypes/AppifySheets.Immutable.BankIntegrationTypes.csproj
+      # Use .NET 8.0
+      dotnet-version: '8.0.x'
+      # Build in Release configuration
+      build-configuration: 'Release'
+      # Version will be extracted from tag or project file
+      package-version: ''
+      # Include symbol packages for debugging
+      include-symbols: true
+      # Include source in packages
+      include-source: true
+      # Push to NuGet.org
+      push-to-nuget: true
+      # Validate packages before publishing
+      validate-package: true
+    secrets:
+      # Pass the NuGet API key from repository secrets
+      nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+
+  # Create GitHub release - only on version tags
+  create-release:
+    name: Create GitHub Release
+    # Only run on version tags
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish-nuget
+    uses: AppifySheets/github-workflows/.github/workflows/github-release.yml@master
+    with:
+      # Use the tag as release name
+      tag-name: ${{ github.ref_name }}
+      # Auto-generate release notes from commits
+      generate-notes: true
+      # Mark as prerelease if version contains prerelease identifiers
+      prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') || contains(github.ref_name, '-preview') }}
+      # Don't create as draft
+      draft: false
+      # Attach the NuGet packages to the release
+      attach-artifacts: 'nuget-packages'
+      # Create discussion for major releases
+      discussion-category: ${{ startsWith(github.ref_name, 'v1.') && 'announcements' || '' }}
+
+  # Status check job - provides single status for branch protection
+  status-check:
+    name: CI Status
+    if: always()
+    needs: [build-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status
+        run: |
+          # Check if all required jobs succeeded
+          if [[ "${{ needs.build-test.result }}" != "success" ]]; then
+            echo "Build and test failed"
+            exit 1
+          fi
+          echo "✅ All checks passed!"

--- a/AppifySheets.Immutable.BankIntegrationTypes/AppifySheets.Immutable.BankIntegrationTypes.csproj
+++ b/AppifySheets.Immutable.BankIntegrationTypes/AppifySheets.Immutable.BankIntegrationTypes.csproj
@@ -1,6 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    
+    <!-- NuGet Package Metadata -->
+    <PackageId>AppifySheets.Immutable.BankIntegrationTypes</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>AppifySheets</Authors>
+    <Company>AppifySheets</Company>
+    <Description>Immutable bank integration types and value objects for Georgian banking systems. Provides strongly-typed, functional data structures for bank accounts, currencies, and transfers.</Description>
+    <PackageTags>Banking;Immutable;ValueObjects;Georgia;TBC;Types</PackageTags>
+    <RepositoryUrl>https://github.com/AppifySheets/TBC-IntegrationService-StandardPlus-Client</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/AppifySheets/TBC-IntegrationService-StandardPlus-Client</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="*" />

--- a/AppifySheets.TBC.IntegrationService.Client/AppifySheets.TBC.IntegrationService.Client.csproj
+++ b/AppifySheets.TBC.IntegrationService.Client/AppifySheets.TBC.IntegrationService.Client.csproj
@@ -2,6 +2,22 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
+        
+        <!-- NuGet Package Metadata -->
+        <PackageId>AppifySheets.TBC.IntegrationService.Client</PackageId>
+        <Version>1.0.0</Version>
+        <Authors>AppifySheets</Authors>
+        <Company>AppifySheets</Company>
+        <Description>Type-safe C#/.NET 8 client for TBC Bank IntegrationService Standard+. Provides immutable, functional wrapper around TBC's SOAP API for payment operations, account movements, and treasury transfers.</Description>
+        <PackageTags>TBC;Bank;Integration;SOAP;Payment;Banking;Georgia</PackageTags>
+        <RepositoryUrl>https://github.com/AppifySheets/TBC-IntegrationService-StandardPlus-Client</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageProjectUrl>https://github.com/AppifySheets/TBC-IntegrationService-StandardPlus-Client</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,6 +28,10 @@
         <PackageReference Include="JetBrains.Annotations" Version="*" />
         <PackageReference Include="Newtonsoft.Json" Version="*" />
         <PackageReference Include="Serilog" Version="*" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a .NET 8.0 C# class library that provides a type-safe, immutable wrapper around TBC Bank's Integration Service Standard+ SOAP API. The library aims to simplify working with the bank's complex SOAP interface by providing clean, functional abstractions.
+
+## Build and Test Commands
+
+```bash
+# Build the solution
+dotnet build
+
+# Run all tests
+dotnet test
+
+# Run a specific test
+dotnet test --filter "FullyQualifiedName~TestClassName.TestMethodName"
+
+# Run the demo console application
+dotnet run --project AppifySheets.TBC.IntegrationService.Client.DemoConsole
+```
+
+## Architecture and Code Structure
+
+### Key Design Principles
+- **Immutable Data Structures**: All data types are immutable records or value objects
+- **Functional Programming**: Uses `CSharpFunctionalExtensions` for Result pattern and error handling
+- **Type Safety**: Strong typing with specific interfaces for different transfer types (within bank, to other banks, treasury)
+- **SOAP Abstraction**: Complex SOAP operations are wrapped in a clean, type-safe API
+
+### Project Structure
+- `AppifySheets.TBC.IntegrationService.Client` - Main client library with SOAP infrastructure
+  - `SoapInfrastructure/` - SOAP request/response classes for each operation
+  - `TBCSoapCaller.cs` - Main entry point for API calls
+- `AppifySheets.Immutable.BankIntegrationTypes` - Shared immutable types and value objects
+- `AppifySheets.TBC.IntegrationService.Tests` - xUnit tests with Shouldly assertions
+- `AppifySheets.TBC.IntegrationService.Client.DemoConsole` - Example usage
+
+### Key Components
+1. **TBCSoapCaller**: Main service class that handles SOAP communication with certificate authentication
+2. **Request/Response IO Classes**: Type-safe wrappers for each SOAP operation (e.g., `ImportSinglePaymentOrdersRequestIo`)
+3. **Transfer Type Interfaces**: Different interfaces for various transfer types (`ITransferWithinBank`, `ITransferToOtherBankNationalCurrency`, etc.)
+4. **Value Objects**: Strongly-typed wrappers like `BankAccountV`, `CurrencyV`, `BankAccountWithCurrencyV`
+
+## Development Guidelines
+
+### When Adding New SOAP Operations
+1. Create request/response IO classes in `SoapInfrastructure/[OperationName]/`
+2. Implement `ISoapRequestIo<TResponse>` interface
+3. Use immutable records for data structures
+4. Add XML serialization attributes matching TBC's SOAP schema
+5. Create helper methods if the operation is complex (see `GetAccountMovementsHelper`)
+
+### When Working with Transfer Types
+- All transfer types implement specific interfaces that define required fields
+- Use `TransferTypeRecordSpecific` for common transfer fields
+- Each transfer type has its own validation rules and required fields
+
+### Testing Approach
+- Tests use xUnit framework with Shouldly for assertions
+- Mock SOAP responses for unit tests
+- Integration tests require valid TBC API credentials and certificates
+
+## Important Implementation Details
+
+### Certificate Authentication
+The library uses X.509 certificates (.pfx files) for authentication. Credentials are managed through:
+- `TBCApiCredentials` - Username and password
+- `TBCApiCredentialsWithCertificate` - Adds certificate path and password
+
+### Current Work in Progress
+The codebase has ongoing work to add `PersonalNumber` field support to transfer operations. This field is being added to various transfer type interfaces and the SOAP request infrastructure.
+
+### Error Handling
+- Uses `Result<T>` pattern from CSharpFunctionalExtensions
+- SOAP faults are converted to meaningful error messages
+- Validation happens at multiple levels (value objects, request validation, SOAP response validation)


### PR DESCRIPTION
## Summary
- Adds comprehensive CI/CD workflow using centralized reusable workflows from `AppifySheets/github-workflows`
- Configures NuGet package metadata for both libraries
- Enables automatic package publishing to NuGet.org on version tags

## Changes
1. **CI/CD Workflow** (`.github/workflows/ci-cd.yml`)
   - Build and test on all pushes and PRs
   - Publish NuGet packages on version tags (v*)
   - Create GitHub releases with auto-generated changelogs
   - Status checks for branch protection

2. **NuGet Package Metadata**
   - Added package metadata to `AppifySheets.TBC.IntegrationService.Client.csproj`
   - Added package metadata to `AppifySheets.Immutable.BankIntegrationTypes.csproj`
   - Configured for symbol package generation and documentation

## How It Works
- Push to main or create PR → Run build and tests
- Create version tag (e.g., v1.0.1) → Build, test, publish to NuGet, create GitHub release
- Manual workflow dispatch → Option to publish packages without tag

## Required Setup
Before merging, ensure the repository has the following secret configured:
- `NUGET_API_KEY` - API key for publishing to NuGet.org

## Test Plan
- [x] Workflow syntax validated
- [ ] PR checks will validate the workflow runs correctly
- [ ] After merge: Create a test tag to verify package publishing

*Collaboration by Claude*