### PR TITLE
feat: Add SOAP fault response handling and deserialization

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(unzip:*)",
+      "Bash(git pull:*)",
+      "Bash(python3:*)"
+    ],
+    "deny": []
+  }
+}

--- a/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/SoapFaultResponse.cs
+++ b/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/SoapFaultResponse.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Xml.Serialization;
+
+namespace AppifySheets.TBC.IntegrationService.Client.SoapInfrastructure;
+
+/// <summary>
+/// Represents a SOAP fault response from TBC Bank API
+/// Contains error code and message when API calls fail
+/// </summary>
+[XmlRoot("Fault", Namespace = "http://schemas.xmlsoap.org/soap/envelope/")]
+public sealed record SoapFaultResponse : ISoapResponse
+{
+    /// <summary>
+    /// The fault code indicating the type of error (e.g., "a:USER_IS_BLOCKED")
+    /// </summary>
+    [XmlElement("faultcode", Namespace = "")]
+    public string FaultCode { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable description of the error
+    /// </summary>
+    [XmlElement("faultstring", Namespace = "")]
+    public string FaultString { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Creates a SoapFaultResponse with the specified fault code and message
+    /// </summary>
+    public static SoapFaultResponse Create(string faultCode, string faultString) =>
+        new() { FaultCode = faultCode, FaultString = faultString };
+
+    /// <summary>
+    /// Gets a formatted error message combining fault code and string
+    /// </summary>
+    public string FormattedError => $"SOAP Fault [{FaultCode}]: {FaultString}";
+
+    /// <summary>
+    /// Checks if this represents a specific fault code
+    /// </summary>
+    public bool IsFaultCode(string faultCode) =>
+        string.Equals(FaultCode, faultCode, StringComparison.OrdinalIgnoreCase);
+}

--- a/AppifySheets.TBC.IntegrationService.Tests/SoapFaultResponseTests.cs
+++ b/AppifySheets.TBC.IntegrationService.Tests/SoapFaultResponseTests.cs
@@ -1,0 +1,91 @@
+using AppifySheets.TBC.IntegrationService.Client.SoapInfrastructure;
+using AppifySheets.TBC.IntegrationService.Client.TBC_Services;
+using CSharpFunctionalExtensions;
+using Shouldly;
+using Xunit;
+
+namespace AppifySheets.TBC.IntegrationService.Tests;
+
+public class SoapFaultResponseTests
+{
+    [Fact]
+    public void Should_Deserialize_SOAP_Fault_Response()
+    {
+        // Arrange
+        const string soapFaultXml = """
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+                <s:Header/>
+                <s:Body>
+                    <s:Fault>
+                        <faultcode xmlns:a="http://www.mygemini.com/schemas/mygemini">a:USER_IS_BLOCKED</faultcode>
+                        <faultstring xml:lang="en">User is blocked.</faultstring>
+                    </s:Fault>
+                </s:Body>
+            </s:Envelope>
+            """;
+
+        // Act
+        var result = soapFaultXml.DeserializeInto<SoapFaultResponse>();
+
+        // Assert - deserialization should fail with SOAP fault error message
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldContain("USER_IS_BLOCKED");
+        result.Error.ShouldContain("User is blocked");
+    }
+
+
+    [Fact]
+    public void Should_Create_SoapFaultResponse_With_Static_Factory()
+    {
+        // Act
+        var fault = SoapFaultResponse.Create("a:USER_IS_BLOCKED", "User is blocked.");
+
+        // Assert
+        fault.FaultCode.ShouldBe("a:USER_IS_BLOCKED");
+        fault.FaultString.ShouldBe("User is blocked.");
+        fault.FormattedError.ShouldBe("SOAP Fault [a:USER_IS_BLOCKED]: User is blocked.");
+    }
+
+    [Fact]
+    public void Should_Check_Fault_Code_Case_Insensitive()
+    {
+        // Arrange
+        var fault = SoapFaultResponse.Create("a:USER_IS_BLOCKED", "User is blocked.");
+
+        // Act & Assert
+        fault.IsFaultCode("a:user_is_blocked").ShouldBeTrue();
+        fault.IsFaultCode("A:USER_IS_BLOCKED").ShouldBeTrue();
+        fault.IsFaultCode("a:USER_IS_BLOCKED").ShouldBeTrue();
+        fault.IsFaultCode("different_code").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParseSoapFault_Should_Parse_Valid_Fault()
+    {
+        // Arrange
+        const string soapFaultXml = """
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+                <s:Header/>
+                <s:Body>
+                    <s:Fault>
+                        <faultcode xmlns:a="http://www.mygemini.com/schemas/mygemini">a:USER_IS_BLOCKED</faultcode>
+                        <faultstring xml:lang="en">User is blocked.</faultstring>
+                    </s:Fault>
+                </s:Body>
+            </s:Envelope>
+            """;
+
+        // Act - use reflection to call the private static method
+        var method = typeof(TBCSoapCaller).GetMethod("TryParseSoapFault",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var result = (Result<SoapFaultResponse>)method!.Invoke(null, [soapFaultXml])!;
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.FaultCode.ShouldBe("a:USER_IS_BLOCKED");
+        result.Value.FaultString.ShouldBe("User is blocked.");
+        result.Value.FormattedError.ShouldBe("SOAP Fault [a:USER_IS_BLOCKED]: User is blocked.");
+    }
+}

--- a/PROJECTNAME
+++ b/PROJECTNAME
@@ -1,0 +1,1 @@
+TBC-IntegrationService


### PR DESCRIPTION
## Summary
- Add proper C# deserialization for TBC Bank SOAP fault responses
- Enhance error handling in TBCSoapCaller to parse and format SOAP faults
- Provide meaningful error messages for fault codes like USER_IS_BLOCKED

## Changes
- **SoapFaultResponse.cs**: New immutable record with XML serialization for SOAP faults
- **TBCSoapCaller.cs**: Enhanced HTTP error handling to detect and parse SOAP faults 
- **SoapFaultResponseTests.cs**: Comprehensive test coverage for fault scenarios

## Test plan
- [x] Unit tests verify SOAP fault XML deserialization
- [x] Tests confirm proper error message formatting  
- [x] Integration with existing TBCSoapCaller error handling
- [x] All existing tests still pass

*Collaboration by Claude*