### PR TITLE
Fixed https://github.com/AppifySheets/TBC-IntegrationService-StandardPlus-Client/issues/20

### DIFF
--- a/AppifySheets.TBC.IntegrationService.Client.DemoConsole/Program.cs
+++ b/AppifySheets.TBC.IntegrationService.Client.DemoConsole/Program.cs
@@ -33,15 +33,15 @@ var bankTransferCommonDetails = new BankTransferCommonDetails
     Amount = 0.01m,
     BeneficiaryName = "TEST",
     SenderAccountWithCurrency = ownAccountGEL,
-    Description = "TEST",
-    PersonalNumber = null // Adding required PersonalNumber field
+    Description = "TEST"
 };
 
 var withinBankGel2 = await tbcSoapCaller.GetDeserialized(new ImportSinglePaymentOrdersRequestIo(
     new TransferWithinBankPaymentOrderIo
     {
         RecipientAccountWithCurrency = BankAccount.Create("GE86TB1144836120100002", "GEL").Value,
-        BankTransferCommonDetails = bankTransferCommonDetails
+        BankTransferCommonDetails = bankTransferCommonDetails,
+        PersonalNumber = null
     }));
 
 var withinBankCurrency = await tbcSoapCaller.GetDeserialized(new ImportSinglePaymentOrdersRequestIo(
@@ -52,6 +52,7 @@ var withinBankCurrency = await tbcSoapCaller.GetDeserialized(new ImportSinglePay
             SenderAccountWithCurrency = ownAccountUSD
         },
         RecipientAccountWithCurrency = BankAccount.Create("GE86TB1144836120100002", "USD").Value,
+        PersonalNumber = null
     }));
 
 var toAnotherBankGel = await tbcSoapCaller.GetDeserialized(

--- a/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/ImportSinglePaymentOrders/ImportSinglePaymentOrdersRequestIo.cs
+++ b/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/ImportSinglePaymentOrders/ImportSinglePaymentOrdersRequestIo.cs
@@ -34,7 +34,7 @@ public record ImportSinglePaymentOrdersRequestIo(TransferTypeRecord TransferType
                       <myg:additionalDescription>{TransferType.AdditionalDescription}</myg:additionalDescription>
                       {TransferType.Is<IDescription>(b => $"<myg:description>{b.Description}</myg:description>")}
                       {TransferType.Is<IBeneficiaryName>(b => $"<myg:beneficiaryName>{b.BeneficiaryName}</myg:beneficiaryName>")}
-                      {TransferType.Is<IBeneficiaryName>(b => $"<myg:personalNumber>{b.PersonalNumber}</myg:personalNumber>")}
+                      {TransferType.Is<IPersonalNumber>(b => $"<myg:personalNumber>{b.PersonalNumber}</myg:personalNumber>")}
                       {TransferType.Is<IBeneficiaryTaxCode>(b => $"<myg:beneficiaryTaxCode>{b.BeneficiaryTaxCode}</myg:beneficiaryTaxCode>")}
                       {TransferType.Is<IBeneficiaryForCurrencyTransfer>(b
                           => $"""

--- a/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/ImportSinglePaymentOrders/TransferTypeInterfaces.cs
+++ b/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/ImportSinglePaymentOrders/TransferTypeInterfaces.cs
@@ -10,7 +10,6 @@ public sealed record BankTransferCommonDetails
     public required long DocumentNumber { get; init; }
     public required decimal Amount { get; init; }
     public required string BeneficiaryName { get; init; }
-    public required string? PersonalNumber { get; init; }
     public required string Description { get; init; }
     public string? AdditionalDescription { get; init; }
 }
@@ -23,7 +22,7 @@ public abstract record TransferTypeRecord
     public long DocumentNumber => BankTransferCommonDetails.DocumentNumber;
     public decimal Amount => BankTransferCommonDetails.Amount;
     public string BeneficiaryName => BankTransferCommonDetails.BeneficiaryName;
-    public string? PersonalNumber => BankTransferCommonDetails.PersonalNumber;
+    // public string? PersonalNumber => BankTransferCommonDetails.PersonalNumber;
     public string Description => BankTransferCommonDetails.Description;
     public string? AdditionalDescription => BankTransferCommonDetails.AdditionalDescription;
 }
@@ -31,9 +30,13 @@ public abstract record TransferTypeRecord
 public interface IBeneficiaryName
 {
     public string BeneficiaryName { get; }
-    public string? PersonalNumber { get; }
+    // public string? PersonalNumber { get; }
 }
 
+public interface IPersonalNumber
+{
+    string? PersonalNumber { get; }
+}
 public interface IDescription
 {
     public string Description { get; }

--- a/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/ImportSinglePaymentOrders/TransferTypeRecords.cs
+++ b/AppifySheets.TBC.IntegrationService.Client/SoapInfrastructure/ImportSinglePaymentOrders/TransferTypeRecords.cs
@@ -3,9 +3,10 @@ using JetBrains.Annotations;
 
 namespace AppifySheets.TBC.IntegrationService.Client.SoapInfrastructure.ImportSinglePaymentOrders;
 
-public record TransferWithinBankPaymentOrderIo : TransferTypeRecord, IRecipient, IBeneficiaryName, IDescription
+public record TransferWithinBankPaymentOrderIo : TransferTypeRecord, IRecipient, IBeneficiaryName, IDescription, IPersonalNumber
 {
     public required BankAccount RecipientAccountWithCurrency { get; init; }
+    public required string? PersonalNumber { get; init; }
 }
 
 public record TransferToOtherBankForeignCurrencyPaymentOrderIo(

--- a/AppifySheets.TBC.IntegrationService.Tests/TBCSoapCallerTests.cs
+++ b/AppifySheets.TBC.IntegrationService.Tests/TBCSoapCallerTests.cs
@@ -72,15 +72,15 @@ public class TBCSoapCallerTests
             Amount = 0.01m,
             BeneficiaryName = "TEST",
             SenderAccountWithCurrency = ownAccountGEL,
-            Description = "TEST",
-            PersonalNumber = null // Adding required PersonalNumber field
+            Description = "TEST"
         };
 
         var withinBankGel2 = await _tbcSoapCaller.GetDeserialized(new ImportSinglePaymentOrdersRequestIo(
             new TransferWithinBankPaymentOrderIo
             {
                 RecipientAccountWithCurrency = BankAccount.Create("GE24TB7755145063300001", "GEL").Value,
-                BankTransferCommonDetails = bankTransferCommonDetails
+                BankTransferCommonDetails = bankTransferCommonDetails,
+                PersonalNumber = null
             }));
 
         var withinBankCurrency = await _tbcSoapCaller.GetDeserialized(new ImportSinglePaymentOrdersRequestIo(
@@ -91,6 +91,7 @@ public class TBCSoapCallerTests
                     SenderAccountWithCurrency = ownAccountUSD
                 },
                 RecipientAccountWithCurrency = BankAccount.Create("GE86TB1144836120100002", "USD").Value,
+                PersonalNumber = null
             }));
 
         var toAnotherBankGel = await _tbcSoapCaller.GetDeserialized(


### PR DESCRIPTION
## Summary
- Fixed issue #20 by REMOVING PersonalNumber field from transfers NOT within TBC Bank

## Changes
- Updated ImportSinglePaymentOrdersRequestIo to handle PersonalNumber
- Modified transfer type interfaces to include PersonalNumber field
- Updated transfer type records with PersonalNumber support

*Collaboration by Claude*